### PR TITLE
chore(app): fix react-tap-event-plugin v0.1.7 and npm shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,11 +1,11 @@
 {
   "name": "triage-for-github",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "dependencies": {
     "classnames": {
-      "version": "2.1.3",
+      "version": "2.1.5",
       "from": "classnames@>=2.1.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.1.5.tgz"
     },
     "crossing": {
       "version": "1.0.1",
@@ -19,7 +19,7 @@
     },
     "electron-debug": {
       "version": "0.2.1",
-      "from": "electron-debug@>=0.2.0 <0.3.0",
+      "from": "electron-debug@0.2.1",
       "resolved": "https://registry.npmjs.org/electron-debug/-/electron-debug-0.2.1.tgz"
     },
     "electron-open-link-in-browser": {
@@ -35,7 +35,7 @@
     },
     "electron-template-menu": {
       "version": "1.0.3",
-      "from": "electron-template-menu@>=1.0.3 <2.0.0",
+      "from": "electron-template-menu@1.0.3",
       "resolved": "https://registry.npmjs.org/electron-template-menu/-/electron-template-menu-1.0.3.tgz"
     },
     "formsy-react": {
@@ -44,14 +44,14 @@
       "resolved": "https://registry.npmjs.org/formsy-react/-/formsy-react-0.14.1.tgz"
     },
     "is-empty-object": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "from": "is-empty-object@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-empty-object/-/is-empty-object-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-empty-object/-/is-empty-object-1.1.1.tgz"
     },
     "material-ui": {
-      "version": "0.11.1",
-      "from": "material-ui@>=0.11.0 <0.12.0",
-      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-0.11.1.tgz",
+      "version": "0.12.1",
+      "from": "material-ui@>=0.12.1 <0.13.0",
+      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-0.12.1.tgz",
       "dependencies": {
         "react-draggable2": {
           "version": "0.5.1",
@@ -61,9 +61,9 @@
       }
     },
     "octokat": {
-      "version": "0.4.11",
+      "version": "0.4.12",
       "from": "octokat@>=0.4.11 <0.5.0",
-      "resolved": "https://registry.npmjs.org/octokat/-/octokat-0.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/octokat/-/octokat-0.4.12.tgz",
       "dependencies": {
         "es6-promise": {
           "version": "2.1.1",
@@ -126,53 +126,29 @@
       }
     },
     "react-redux": {
-      "version": "2.1.2",
-      "from": "react-redux@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-2.1.2.tgz",
+      "version": "3.1.0",
+      "from": "react-redux@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-3.1.0.tgz",
       "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "1.0.3",
+          "from": "hoist-non-react-statics@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.0.3.tgz"
+        },
         "invariant": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "from": "invariant@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.1.1.tgz",
           "dependencies": {
-            "envify": {
-              "version": "3.4.0",
-              "from": "envify@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz",
+            "loose-envify": {
+              "version": "1.0.0",
+              "from": "loose-envify@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.0.0.tgz",
               "dependencies": {
-                "through": {
-                  "version": "2.3.8",
-                  "from": "through@>=2.3.4 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                },
-                "jstransform": {
-                  "version": "10.1.0",
-                  "from": "jstransform@>=10.0.1 <11.0.0",
-                  "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
-                  "dependencies": {
-                    "base62": {
-                      "version": "0.1.1",
-                      "from": "base62@0.1.1",
-                      "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
-                    },
-                    "esprima-fb": {
-                      "version": "13001.1001.0-dev-harmony-fb",
-                      "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
-                    },
-                    "source-map": {
-                      "version": "0.1.31",
-                      "from": "source-map@0.1.31",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.0",
-                          "from": "amdefine@>=0.0.4",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
+                "js-tokens": {
+                  "version": "1.0.1",
+                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
                 }
               }
             }
@@ -186,48 +162,19 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-1.0.0-beta3.tgz",
       "dependencies": {
         "invariant": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "from": "invariant@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.1.1.tgz",
           "dependencies": {
-            "envify": {
-              "version": "3.4.0",
-              "from": "envify@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz",
+            "loose-envify": {
+              "version": "1.0.0",
+              "from": "loose-envify@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.0.0.tgz",
               "dependencies": {
-                "through": {
-                  "version": "2.3.8",
-                  "from": "through@>=2.3.4 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                },
-                "jstransform": {
-                  "version": "10.1.0",
-                  "from": "jstransform@>=10.0.1 <11.0.0",
-                  "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
-                  "dependencies": {
-                    "base62": {
-                      "version": "0.1.1",
-                      "from": "base62@0.1.1",
-                      "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
-                    },
-                    "esprima-fb": {
-                      "version": "13001.1001.0-dev-harmony-fb",
-                      "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
-                    },
-                    "source-map": {
-                      "version": "0.1.31",
-                      "from": "source-map@0.1.31",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.0",
-                          "from": "amdefine@>=0.0.4",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
+                "js-tokens": {
+                  "version": "1.0.1",
+                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
                 }
               }
             }
@@ -252,13 +199,18 @@
     },
     "react-tap-event-plugin": {
       "version": "0.1.7",
-      "from": "react-tap-event-plugin@>=0.1.7 <0.2.0",
+      "from": "react-tap-event-plugin@0.1.7",
       "resolved": "https://registry.npmjs.org/react-tap-event-plugin/-/react-tap-event-plugin-0.1.7.tgz"
     },
     "redux": {
-      "version": "3.0.0",
+      "version": "3.0.2",
       "from": "redux@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/redux/-/redux-3.0.2.tgz"
+    },
+    "redux-batched-updates": {
+      "version": "0.1.0",
+      "from": "redux-batched-updates@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/redux-batched-updates/-/redux-batched-updates-0.1.0.tgz"
     },
     "redux-react-router": {
       "version": "0.4.0",
@@ -266,12 +218,12 @@
       "resolved": "https://registry.npmjs.org/redux-react-router/-/redux-react-router-0.4.0.tgz"
     },
     "redux-thunk": {
-      "version": "0.1.0",
-      "from": "redux-thunk@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-0.1.0.tgz"
+      "version": "1.0.0",
+      "from": "redux-thunk@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-1.0.0.tgz"
     },
     "reset-storage": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "from": "reset-storage@>=1.0.1 <2.0.0",
       "dependencies": {
         "es6-promise": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react": "^0.13.3",
     "react-redux": "^3.0.1",
     "react-router": "1.0.0-beta3",
-    "react-tap-event-plugin": "^0.1.7",
+    "react-tap-event-plugin": "0.1.7",
     "redux": "^3.0.0",
     "redux-batched-updates": "^0.1.0",
     "redux-react-router": "0.4.0",


### PR DESCRIPTION
- fix react-tap-event-plugin v0.1.7
  - 0.1.8 has breaking change (using react v0.14)
- `npm shrinkwrap`
